### PR TITLE
Fixes 500 errors when running on Now hosting

### DIFF
--- a/now.json
+++ b/now.json
@@ -8,12 +8,12 @@
     }
   ],
   "routes": [
-    { 
-      "src": "/favicon.ico", 
-      "dest": "/static/favicon.ico" 
+    {
+      "src": "/favicon.ico",
+      "dest": "/static/favicon.ico"
     },
     {
-      "src": "/(.*)$",
+      "src": "/^(?!(_next)).+$",
       "dest": "/index?slug=$1"
     }
   ]


### PR DESCRIPTION
When running on Now hosting, either with the `now dev` command locally or on the actual cloud service, I was getting 500 errors for all files being requested from the `_next` directory.  I believe this can be resolved with a Regex change to the `src` property for rewriting URLs to point to the index page.  You can [test this on regex101 here](https://regex101.com/r/z1tpBT/1).