### PR TITLE
fix: error `Missing Document Components`

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,4 +1,4 @@
-import Document, { Head, Main, NextScript } from 'next/document'
+import Document, { Html, Head, Main, NextScript } from 'next/document'
 import StoryblokService from '../utils/StoryblokService'
 
 export default class MyDocument extends Document {
@@ -9,7 +9,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <html>
+      <Html>
         <Head>
           <script dangerouslySetInnerHTML={{__html: `var StoryblokCacheVersion = '${StoryblokService.getCacheVersion()}';` }}></script>
         </Head>
@@ -17,7 +17,7 @@ export default class MyDocument extends Document {
           <Main />
           <NextScript />
         </body>
-      </html>
+      </Html>
     )
   }
 }


### PR DESCRIPTION
`<Html>` is now required in custom _document : [NextJS documentation - Custom Document](https://nextjs.org/docs/advanced-features/custom-document)