### PR TITLE
Use storyblok-editable

### DIFF
--- a/components/DynamicComponent.js
+++ b/components/DynamicComponent.js
@@ -1,29 +1,37 @@
-import { useRouter } from 'next/router'
-import SbEditable from 'storyblok-react'
-import Teaser from './Teaser'
-import Grid from './Grid'
-import Feature from './Feature'
-import Page from './Page'
- 
+import { useRouter } from "next/router";
+import { sbEditable } from "@storyblok/storyblok-editable";
+import Teaser from "./Teaser";
+import Grid from "./Grid";
+import Feature from "./Feature";
+import Page from "./Page";
+
 // resolve Storyblok components to Next.js components
 const Components = {
-  'teaser': Teaser,
-  'grid': Grid,
-  'feature': Feature,
-  'page': Page,
-}
- 
-const DynamicComponent = ({blok}) => {
-  const { isPreview } = useRouter()
+  teaser: Teaser,
+  grid: Grid,
+  feature: Feature,
+  page: Page,
+};
+
+const DynamicComponent = ({ blok }) => {
+  const { isPreview } = useRouter();
   // check if component is defined above
-  if (typeof Components[blok.component] !== 'undefined') {
-    const Component = Components[blok.component]
-    // wrap with SbEditable for visual editing
-    return isPreview ? (<SbEditable content={blok}><Component blok={blok} /></SbEditable>) : <Component blok={blok} />
+  if (typeof Components[blok.component] !== "undefined") {
+    const Component = Components[blok.component];
+
+    return isPreview ? (
+      <Component blok={blok} {...sbEditable(blok)} key={blok._uid} />
+    ) : (
+      <Component blok={blok} />
+    );
   }
-  
+
   // fallback if the component doesn't exist
-  return (<p>The component <strong>{blok.component}</strong> has not been created yet.</p>)
-}
- 
-export default DynamicComponent
+  return (
+    <p>
+      The component <strong>{blok.component}</strong> has not been created yet.
+    </p>
+  );
+};
+
+export default DynamicComponent;

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-    "name": "react-next-storyblok-boilerplate",
-    "version": "1.0.0",
-    "description": "Next.js Storyblok Boilerplate",
-    "main": "index.js",
-    "private": true,
-    "scripts": {
-        "dev": "next dev",
-        "build": "next build",
-        "start": "next start"
-    },
-    "dependencies": {
-        "axios": "^0.21.1",
-        "next": "10.2.0",
-        "react": "17.0.2",
-        "react-dom": "17.0.2",
-        "storyblok-js-client": "^4.0.7",
-        "storyblok-react": "^0.1.2"
-    }
+  "name": "react-next-storyblok-boilerplate",
+  "version": "1.0.0",
+  "description": "Next.js Storyblok Boilerplate",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@storyblok/storyblok-editable": "^1.0.0",
+    "axios": "^0.21.1",
+    "next": "10.2.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "storyblok-js-client": "^4.0.7"
+  }
 }


### PR DESCRIPTION
We created a new `storyblok-editable` npm package to use instead of `storyblok-react`:

https://github.com/storyblok/storyblok-editable

Replace the package in both the repository and the tutorial.

https://www.notion.so/storyblok/Update-relevant-tutorials-for-storyblok-editable-npm-package-23c7f827c2774e3b8a053715a904150d

https://app.storyblok.com/#!/me/spaces/88751/stories/0/0/33402846 