### PR TITLE
FIX ISSUE #17 UPDATING STORY WITHOUT PREVIEW

### DIFF
--- a/lib/storyblok.js
+++ b/lib/storyblok.js
@@ -78,6 +78,10 @@ export function useStoryblok(originalStory, preview) {
     }
   }, [originalStory, preview, setStory]); // runs the effect only once & defines effect dependencies
 
+  useEffect(() => {
+    setStory(originalStory);
+  }, [originalStory])
+
   return story;
 }
 


### PR DESCRIPTION
The original story will not update if we are not in preview mod.

This Pull request add a useEffect to detect changes in the props and update the current story if we pass another story by props.
Without this the story only update if we are in preview can't be updated if we are not in preview.

ISSUE #17 